### PR TITLE
Add Labels in Metadata to be returned by Search

### DIFF
--- a/src/Dapplo.Confluence.Tests/ContentTests.cs
+++ b/src/Dapplo.Confluence.Tests/ContentTests.cs
@@ -145,6 +145,15 @@ namespace Dapplo.Confluence.Tests
             var bitmap = await _confluenceClient.Attachment.GetContentAsync<Bitmap>(attachment);
             Assert.True(bitmap.Width > 0);
         }
+        
+        [Fact]
+        public async Task TestSearchLabels()
+        {
+            ConfluenceClientConfig.ExpandSearch = new[] { "version", "space", "space.icon", "space.description", "space.homepage", "history.lastUpdated", "metadata.labels" };
+
+            var searchResult = await _confluenceClient.Content.SearchAsync(Where.And(Where.Type.IsPage, Where.Text.Contains("Test Home")), limit: 1);
+            Assert.NotEmpty(searchResult.First().Metadata.Labels.Results);
+        }
 
         //[Fact]
         public async Task TestLabels()

--- a/src/Dapplo.Confluence/Entities/Metadata.cs
+++ b/src/Dapplo.Confluence/Entities/Metadata.cs
@@ -24,5 +24,11 @@ namespace Dapplo.Confluence.Entities
         /// </summary>
         [JsonProperty("mediaType", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string MediaType { get; set; }
+        
+        /// <summary>
+        ///     Labels associated to content
+        /// </summary>
+        [JsonProperty("labels", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Result<Label> Labels { get; set; }
     }
 }


### PR DESCRIPTION
When expand search with 'metadata.labels', add the missing field we we can retrieve labels of the page.
Add tentative test, was not able to run it