### PR TITLE
Added support for paging using cursor in search results.

### DIFF
--- a/src/Dapplo.Confluence.Tests/JsonTestFiles/search.json
+++ b/src/Dapplo.Confluence.Tests/JsonTestFiles/search.json
@@ -29,6 +29,7 @@
 	"size": 1,
 	"_links": {
 		"self": "https://greenshot.atlassian.net/wiki/rest/api/content/search?cql=text%20~%20%22greenshot%22",
+		"next": "/rest/api/search?cql=text%20~%20%22greenshot%22&limit=25&cursor=raNDoMsTRiNg",
 		"base": "https://greenshot.atlassian.net/wiki",
 		"context": "/wiki"
 	}

--- a/src/Dapplo.Confluence/Entities/CursorBasedResult.cs
+++ b/src/Dapplo.Confluence/Entities/CursorBasedResult.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Dapplo.Confluence.Entities
+{
+    /// <summary>
+    ///     A container to store pageable results that need a cursor to be paged.
+    ///     See: https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-search/
+    /// </summary>
+    /// <typeparam name="TResult"></typeparam>
+    public class CursorBasedResult<TResult> : Result<TResult>
+    {
+        private string cursor = null;
+
+        /// <summary>
+        /// Cursor needed to page trought the results.
+        /// </summary>
+        [JsonIgnore]
+        public string Cursor
+        {
+            get
+            {
+                if (!HasNext) return null;
+                if (cursor == null)
+                {
+                    var querystring = Links.Next.OriginalString.Substring(Links.Next.OriginalString.IndexOf('?'));
+                    cursor = UriParseExtensions.QueryStringToDictionary(querystring)?["cursor"];
+                }
+                return cursor;
+            }
+        }
+    }
+}

--- a/src/Dapplo.Confluence/Entities/SearchDetails.cs
+++ b/src/Dapplo.Confluence/Entities/SearchDetails.cs
@@ -31,4 +31,9 @@ public class SearchDetails : PagingInformation
     /// Specify the search expand values, default is what is specified in the ConfluenceClientConfig.ExpandSearch
     /// </summary>
     public IEnumerable<string> ExpandSearch { get; set; } = ConfluenceClientConfig.ExpandSearch;
+
+    /// <summary>
+    /// Cursor used to page trought search results.
+    /// </summary>
+    public string Cursor { get; set; }
 }


### PR DESCRIPTION
Now the SDK supports paging search results using the cursor query string parameter, as mentioned on [this](https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-search/) page in confluence documentation.

Here is a usage example:

``` csharp
var query = Where.And(Where.Space.Is("Default"), Where.Type.IsPage, Where.Title.Contains("Something"));
var hasNext = false;
var results = new List<Content>();
int limit = 25;
int start = 0;
string cursor = null;

do
{
    var paging = new PagingInformation() { Limit = limit, Start = start };
    var searchResult = await _confluenceClient.Content.SearchAsync(query, cursor: cursor, cancellationToken: cancellationToken);
    hasNext = searchResult.HasNext;
    cursor = searchResult.Cursor;
    results.AddRange(searchResult.Results);
    start += limit;
} while (hasNext);
```